### PR TITLE
fix: NRE・ゼロ除算・StopWatch多重ループを修正

### DIFF
--- a/Runtime/jp.ootr.ImageSlide/Scripts/22_LogicQueue.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/22_LogicQueue.cs
@@ -507,8 +507,8 @@ namespace jp.ootr.ImageSlide
 
         private void UpdateList(DataToken data)
         {
-            if (!data.DataDictionary.TryGetValue("sources", out var sources) ||
-                !data.DataDictionary.TryGetValue("options", out var options) ||
+            if (!data.DataDictionary.TryGetValue("sources", TokenType.DataList, out var sources) ||
+                !data.DataDictionary.TryGetValue("options", TokenType.DataList, out var options) ||
                 sources.DataList.Count != options.DataList.Count)
             {
                 ConsoleError($"sources or options not found in update list: {data}", _logicQueuePrefix);

--- a/Runtime/jp.ootr.ImageSlide/Scripts/41_UIDeviceList.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/41_UIDeviceList.cs
@@ -20,6 +20,7 @@ namespace jp.ootr.ImageSlide
         public override void InitController()
         {
             base.InitController();
+            if (deviceSelectedUuids == null) deviceSelectedUuids = new string[0];
             if (isDeviceListLocked) settingsTitleText.text = $"{settingsTitleText.text} (Locked)";
             _deviceToggles = new Toggle[rootDeviceTransform.childCount];
             var index = 0;

--- a/Runtime/jp.ootr.ImageSlide/Scripts/42_UISlide.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/42_UISlide.cs
@@ -50,6 +50,7 @@ namespace jp.ootr.ImageSlide
 
         public void SeekToEnd()
         {
+            if (slideCount <= 0) return;
             if (currentIndex == slideCount - 1) return;
             SeekTo(slideCount - 1);
         }
@@ -119,13 +120,15 @@ namespace jp.ootr.ImageSlide
             if (texture != slideMainView.texture)
             {
                 slideMainView.texture = texture;
-                slideMainViewFitter.aspectRatio = (float)texture.width / texture.height;
+                if (texture.height > 0)
+                    slideMainViewFitter.aspectRatio = (float)texture.width / texture.height;
             }
         }
 
         private void CastToScreens(string source, string fileName)
         {
             if (!Networking.IsOwner(gameObject)) return;
+            if (devices == null) return;
             foreach (var device in devices)
             {
                 if (device == null || !device.IsCastableDevice() ||

--- a/Runtime/jp.ootr.ImageSlide/Scripts/43_UIThumbnails.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/43_UIThumbnails.cs
@@ -190,7 +190,8 @@ namespace jp.ootr.ImageSlide
                 return;
             }
             _thumbnailListThumbnails[index].texture = texture;
-            _thumbnailListFitters[index].aspectRatio = (float)texture.width / texture.height;
+            if (texture.height > 0)
+                _thumbnailListFitters[index].aspectRatio = (float)texture.width / texture.height;
             _thumbnailListLoadingSpinners[index].SetActive(false);
         }
     }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/44_UINextSlide.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/44_UINextSlide.cs
@@ -66,7 +66,8 @@ namespace jp.ootr.ImageSlide
             var texture = controller.CcGetTexture(sourceUrl, fileUrl);
             if (texture == null) return;
             slideNextView.texture = texture;
-            slideNextViewFitter.aspectRatio = (float)texture.width / texture.height;
+            if (texture.height > 0)
+                slideNextViewFitter.aspectRatio = (float)texture.width / texture.height;
         }
     }
 }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/51_UIStopWatch.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/51_UIStopWatch.cs
@@ -35,7 +35,7 @@ namespace jp.ootr.ImageSlide
         public void ResetStopWatch()
         {
             _stopWatchTime = DateTime.Now.ToUnixTime();
-            stopWatchText.text = "00:00:00";
+            if (stopWatchText != null) stopWatchText.text = "00:00:00";
             _isStopWatchRunning = false;
             _stopWatchOffset = 0;
             animator.SetInteger(_animatorStopWatchState, 0);
@@ -55,7 +55,8 @@ namespace jp.ootr.ImageSlide
             }
 
             var time = TimeSpan.FromSeconds(DateTime.Now.ToUnixTime() - _stopWatchTime);
-            stopWatchText.text = $"{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}";
+            if (stopWatchText != null)
+                stopWatchText.text = $"{(int)time.TotalHours:D2}:{time.Minutes:D2}:{time.Seconds:D2}";
             _isTickScheduled = true;
             SendCustomEventDelayedSeconds(nameof(CountUpStopWatch), 0.1f);
         }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/51_UIStopWatch.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/51_UIStopWatch.cs
@@ -11,6 +11,7 @@ namespace jp.ootr.ImageSlide
 
         private readonly int _animatorStopWatchState = Animator.StringToHash("StopWatchState");
         private bool _isStopWatchRunning;
+        private bool _isTickScheduled;
         private ulong _stopWatchOffset;
 
         private ulong _stopWatchTime;
@@ -26,6 +27,8 @@ namespace jp.ootr.ImageSlide
             animator.SetInteger(_animatorStopWatchState, 1);
             _stopWatchTime = DateTime.Now.ToUnixTime() - _stopWatchOffset;
             _isStopWatchRunning = true;
+            if (_isTickScheduled) return;
+            _isTickScheduled = true;
             SendCustomEventDelayedSeconds(nameof(CountUpStopWatch), 0.1f);
         }
 
@@ -40,8 +43,12 @@ namespace jp.ootr.ImageSlide
 
         public void CountUpStopWatch()
         {
+            _isTickScheduled = false;
             if (!_isStopWatchRunning)
             {
+                // Reset 直後の pending tick はスキップ(state 0 == Idle)。
+                // Stop(pause) の場合のみ state 2 に遷移して経過分を offset に退避する。
+                if (animator.GetInteger(_animatorStopWatchState) == 0) return;
                 animator.SetInteger(_animatorStopWatchState, 2);
                 _stopWatchOffset = DateTime.Now.ToUnixTime() - _stopWatchTime;
                 return;
@@ -49,6 +56,7 @@ namespace jp.ootr.ImageSlide
 
             var time = TimeSpan.FromSeconds(DateTime.Now.ToUnixTime() - _stopWatchTime);
             stopWatchText.text = $"{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}";
+            _isTickScheduled = true;
             SendCustomEventDelayedSeconds(nameof(CountUpStopWatch), 0.1f);
         }
     }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/52_UIClock.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/52_UIClock.cs
@@ -16,6 +16,7 @@ namespace jp.ootr.ImageSlide
 
         public void ClockTick()
         {
+            if (clockText == null) return;
             UpdateClockText();
             SendCustomEventDelayedSeconds(nameof(ClockTick), 0.25f);
         }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/13_UISlide.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/13_UISlide.cs
@@ -172,7 +172,8 @@ namespace jp.ootr.ImageSlide.Viewer
         {
             if (texture == null) return;
             slideMainView.texture = texture;
-            slideMainViewFitter.aspectRatio = (float)texture.width / texture.height;
+            if (texture.height > 0)
+                slideMainViewFitter.aspectRatio = (float)texture.width / texture.height;
         }
     }
 }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/17_UIThumbnails.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/17_UIThumbnails.cs
@@ -24,6 +24,7 @@ namespace jp.ootr.ImageSlide.Viewer
         private TextMeshProUGUI[] _slideListTexts = new TextMeshProUGUI[0];
         private RawImage[] _slideListThumbnails = new RawImage[0];
         private AspectRatioFitter[] _slideListFitters = new AspectRatioFitter[0];
+        private GameObject[] _slideListLoadingSpinners = new GameObject[0];
 
         private RectTransform _slideListViewRootRectTransform;
         private RectTransform _slideListViewRectTransform;
@@ -119,7 +120,7 @@ namespace jp.ootr.ImageSlide.Viewer
                 _slideListThumbnails = _slideListThumbnails.Resize(slideCount);
                 _slideListFitters = _slideListFitters.Resize(slideCount);
                 _slideListTexts = _slideListTexts.Resize(slideCount);
-                _thumbnailListLoadingSpinners = _thumbnailListLoadingSpinners.Resize(slideCount);
+                _slideListLoadingSpinners = _slideListLoadingSpinners.Resize(slideCount);
 
                 for (var i = currentLength; i < slideCount; i++)
                 {
@@ -131,8 +132,8 @@ namespace jp.ootr.ImageSlide.Viewer
                     _slideListThumbnails[i] = obj.transform.Find("GameObject/RawImage").GetComponent<RawImage>();
                     _slideListFitters[i] = obj.transform.Find("GameObject/RawImage").GetComponent<AspectRatioFitter>();
                     _slideListTexts[i] = obj.transform.Find("Text (TMP)").GetComponent<TextMeshProUGUI>();
-                    _thumbnailListLoadingSpinners[i] = obj.transform.Find("LoadingSpinner").gameObject;
-                    _thumbnailListLoadingSpinners[i].SetActive(false);
+                    _slideListLoadingSpinners[i] = obj.transform.Find("LoadingSpinner").gameObject;
+                    _slideListLoadingSpinners[i].SetActive(false);
                     ConsoleDebug(
                         $"{_slideListToggles[i]}, {_slideListThumbnails[i]}, {_slideListFitters[i]}, {_slideListTexts[i]}");
                 }
@@ -147,7 +148,7 @@ namespace jp.ootr.ImageSlide.Viewer
                 _slideListThumbnails = _slideListThumbnails.Resize(slideCount);
                 _slideListFitters = _slideListFitters.Resize(slideCount);
                 _slideListTexts = _slideListTexts.Resize(slideCount);
-                _thumbnailListLoadingSpinners = _thumbnailListLoadingSpinners.Resize(slideCount);
+                _slideListLoadingSpinners = _slideListLoadingSpinners.Resize(slideCount);
                 slideListViewRoot.ToListChildrenHorizontal(16, 16, true);
             }
 
@@ -231,7 +232,7 @@ namespace jp.ootr.ImageSlide.Viewer
                 {
                     ConsoleDebug($"loading thumbnail: {source} {fileName}");
                     controller.LoadFile(this, source, fileName);
-                    _thumbnailListLoadingSpinners[i].SetActive(true);
+                    _slideListLoadingSpinners[i].SetActive(true);
                 }
             }
         }
@@ -249,9 +250,9 @@ namespace jp.ootr.ImageSlide.Viewer
 
             ConsoleDebug($"thumbnail image loaded: {fileUrl}");
             // エラー時も読み込み表示を解除
-            if (index < _thumbnailListLoadingSpinners.Length)
+            if (index < _slideListLoadingSpinners.Length)
             {
-                _thumbnailListLoadingSpinners[index].SetActive(false);
+                _slideListLoadingSpinners[index].SetActive(false);
             }
 
             var texture = controller.CcGetTexture(sourceUrl, fileUrl);
@@ -287,8 +288,8 @@ namespace jp.ootr.ImageSlide.Viewer
                 }
             }
             if (index == -1) return;
-            if (index >= _thumbnailListLoadingSpinners.Length) return;
-            _thumbnailListLoadingSpinners[index].SetActive(false);
+            if (index >= _slideListLoadingSpinners.Length) return;
+            _slideListLoadingSpinners[index].SetActive(false);
             ConsoleError($"thumbnail image load error: {error} {sourceUrl}/{fileUrl}");
         }
     }

--- a/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/17_UIThumbnails.cs
+++ b/Runtime/jp.ootr.ImageSlide/Scripts/Viewer/17_UIThumbnails.cs
@@ -28,8 +28,8 @@ namespace jp.ootr.ImageSlide.Viewer
         private RectTransform _slideListViewRootRectTransform;
         private RectTransform _slideListViewRectTransform;
 
-        private string[] _slideListLoadedSources;
-        private string[] _slideListLoadedFileNames;
+        private string[] _slideListLoadedSources = new string[0];
+        private string[] _slideListLoadedFileNames = new string[0];
 
         public override void InitImageSlide()
         {
@@ -268,7 +268,8 @@ namespace jp.ootr.ImageSlide.Viewer
             }
 
             _slideListThumbnails[index].texture = texture;
-            _slideListFitters[index].aspectRatio = (float)texture.width / texture.height;
+            if (texture.height > 0)
+                _slideListFitters[index].aspectRatio = (float)texture.width / texture.height;
         }
 
         public override void OnFileLoadError(string sourceUrl, string fileUrl, string channel, LoadError error)


### PR DESCRIPTION
- Viewer/17_UIThumbnails: _slideListLoadedSources/FileNames を new string[0] で初期化し、初回 BuildSlideList() での NRE を解消
- LogicQueue.UpdateList: TokenType.DataList フィルタを追加し、細工された SyncQueue による NRE を防止
- 5箇所の aspectRatio 計算に texture.height > 0 ガードを追加しゼロ除算・NaN 伝播を防止 (42_UISlide, 43_UIThumbnails, 44_UINextSlide, Viewer/13_UISlide, Viewer/17_UIThumbnails)
- UIStopWatch: _isTickScheduled フラグで CountUpStopWatch の多重スケジュールを防止 Reset 直後の pending tick が offset を破壊しないよう animator state 0 を判定して早期 return
- UISlide.SeekToEnd: slideCount <= 0 ガードで空スライド時の SeekTo(-1) 送信を防止
- UISlide.CastToScreens: devices == null ガードを追加
- UIDeviceList.InitController: deviceSelectedUuids を空配列に正規化し locked 時の NRE を防止
- UIClock.ClockTick: clockText == null ガードを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed division-by-zero vulnerabilities in image aspect-ratio calculations across multiple UI components.
  * Added null-safety checks to prevent crashes from missing UI references and invalid device collections.
  * Prevented duplicate timer events from being scheduled.
  * Added validation guards for slide counts and image dimensions before processing.
  * Improved data structure type validation to ensure expected formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->